### PR TITLE
Fix example input file

### DIFF
--- a/Examples/Data/geometries.csv
+++ b/Examples/Data/geometries.csv
@@ -1,3 +1,3 @@
 title,geom_data,x,y,z,m
 "Geom0","LINESTRING (0 0, 1 1)",1,2,3,4
-"Geom1","LINESTRING (10 10, 5 5)",10,20,,,
+"Geom1","LINESTRING (10 10, 5 5)",10,20,,


### PR DESCRIPTION
Fix GISNET-2041 black box test failure caused by an extra trailing comma in the expected CSV output.

The expected line was corrected from:

```csv
"Geom1","LINESTRING (10 10, 5 5)",10,20,,,
```

to:

```csv
"Geom1","LINESTRING (10 10, 5 5)",10,20,,
```

This aligns the expected output with the actual number of exported fields in the example.
